### PR TITLE
fix: Ensure parameter emptiness check before casting for non-required parameters

### DIFF
--- a/src/mg/emberframework/utils/reflection/ObjectUtils.java
+++ b/src/mg/emberframework/utils/reflection/ObjectUtils.java
@@ -40,7 +40,7 @@ public class ObjectUtils {
         if (ClassUtils.isPrimitive(clazz)) {
             strValue = getParamStringValue(parameter, request);
 
-            if (strValue != null) {
+            if (strValue != null && !strValue.isEmpty()) {
                 object = ObjectConverter.castObject(strValue, clazz);
             }
             


### PR DESCRIPTION
### Overview
This pull request addresses an issue where non-required parameters were being cast without prior validation, potentially leading to errors or unexpected behavior. The update introduces a safeguard to ensure that parameter values are checked for emptiness before casting, improving the robustness of the system.

---

### Changes Made
- Added a validation step to check for empty parameter values prior to casting, specifically targeting non-required parameters.  
- Enhanced error prevention by ensuring the casting process only proceeds with valid, non-empty parameter data.